### PR TITLE
Enable table support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,7 @@ install:
   - pip install tox
 script:
   - tox -e $TOX_ENV
+before_install: # or any other customizable place
+  - source ~/virtualenv/python3.5/bin/activate
 after_success:
   coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - '3.6'
-sudo: false
 before_install:
   - if [[ $TOX_ENV = py35 && -f ~/virtualenv/python3.5/bin/activate ]]; then source ~/virtualenv/python3.5/bin/activate; fi
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 python:
-  - 3.6
+  - '3.6'
+sudo: false
+before_install:
+  - if [[ $TOXENV = py35 && -f ~/virtualenv/python3.5/bin/activate ]]; then source ~/virtualenv/python3.5/bin/activate; fi
 env:
   - TOX_ENV=flake8
   - TOX_ENV=py27
@@ -11,7 +14,5 @@ install:
   - pip install tox
 script:
   - tox -e $TOX_ENV
-before_install: # or any other customizable place
-  - source ~/virtualenv/python3.5/bin/activate
 after_success:
   coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - '3.6'
 sudo: false
 before_install:
-  - if [[ $TOXENV = py35 && -f ~/virtualenv/python3.5/bin/activate ]]; then source ~/virtualenv/python3.5/bin/activate; fi
+  - if [[ $TOX_ENV = py35 && -f ~/virtualenv/python3.5/bin/activate ]]; then source ~/virtualenv/python3.5/bin/activate; fi
 env:
   - TOX_ENV=flake8
   - TOX_ENV=py27

--- a/md2pdf/core.py
+++ b/md2pdf/core.py
@@ -28,7 +28,7 @@ def md2pdf(pdf_file_path, md_content=None, md_file_path=None,
 
     # Convert markdown to html
     raw_html = ''
-    extras = ['cuddled-lists', ]
+    extras = ['cuddled-lists', 'tables']
     if md_file_path:
         raw_html = markdown_path(md_file_path, extras=extras)
     elif md_content:


### PR DESCRIPTION
This PR enables `markdown2`'s `table` extra to support github-style tables.