### PR TITLE
Include custom extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ Optionally, you may load an external style (restricted to CSS2):
 $ md2pdf --css tests/resources/input.css README.md README.pdf
 ```
 
+Optionally, you may add [extras](https://github.com/trentm/python-markdown2/wiki/Extras) to the convertion:
+
+```bash
+$ md2pdf README.md README.pdf --new-extras=fenced-code-blocks
+
+$ md2pdf README.md README.pdf --new-extras=fenced-code-blocks,mermaid
+```
+
 ### As a library
 
 You can use `md2pdf` in your python code, like:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Usage:
 
 Options:
     --css=STYLE.CSS
+    --new-extras=extras1,extras2,extras2 (separated by comma)
 ```
 
 For example, try to generate the project documentation with:
@@ -49,7 +50,8 @@ md2pdf(pdf_file_path,
        md_content=None,
        md_file_path=None,
        css_file_path=None,
-       base_url=None)
+       base_url=None,
+       new_extras=None)
 ```
 
 Function arguments:
@@ -59,6 +61,7 @@ Function arguments:
 * `md_file_path`: input markdown file path
 * `css_file_path`: input styles path (CSS)
 * `base_url`: absolute base path for markdown linked content (as images)
+* `new_extras`: list of new extras separated by comma
 
 ### With Docker
 

--- a/md2pdf/__main__.py
+++ b/md2pdf/__main__.py
@@ -7,6 +7,7 @@ Usage: md2pdf [options] INPUT.MD OUTPUT.PDF
 
 Options:
     --css=STYLE.CSS
+    --new-extras=extras1,extras2,extras2 (separated by comma)
 """
 import os
 import sys
@@ -27,12 +28,15 @@ def main(argv=None):
     md_file_path = arguments.get('INPUT.MD')
     pdf_file_path = arguments.get('OUTPUT.PDF')
     css_file_path = arguments.get('--css', None)
+    new_extras = arguments.get('--new-extras', None)
     base_url = os.getcwd()
-
+    
     md2pdf(pdf_file_path,
            md_file_path=md_file_path,
            css_file_path=css_file_path,
-           base_url=base_url)
+           base_url=base_url,
+           new_extras=new_extras,
+           )
 
     return 0
 

--- a/md2pdf/core.py
+++ b/md2pdf/core.py
@@ -8,7 +8,7 @@ from .exceptions import ValidationError
 
 
 def md2pdf(pdf_file_path, md_content=None, md_file_path=None,
-           css_file_path=None, base_url=None):
+           css_file_path=None, base_url=None, new_extras=None):
     """
     Converts input markdown to styled HTML and renders it to a PDF file.
 
@@ -28,7 +28,12 @@ def md2pdf(pdf_file_path, md_content=None, md_file_path=None,
 
     # Convert markdown to html
     raw_html = ''
-    extras = ['cuddled-lists', 'tables']
+    if new_extras == None:
+        new_extras = []
+    else:
+        new_extras = [x.strip() for x in new_extras.split(',')]
+    extras = ['cuddled-lists', 'tables', 'footnotes']
+    [extras.append(x) for x in new_extras if x not in extras]
     if md_file_path:
         raw_html = markdown_path(md_file_path, extras=extras)
     elif md_content:


### PR DESCRIPTION
Hello, my friends!

First of all, thank you to merge my last [PR](https://github.com/jmaupetit/md2pdf/pull/46)!

As I said there I've been using it quite a lot recently and encountered another situation where more extras were necessary. Instead of hard coding it, as in the last PR, I think a flow to allow users to indicate one or more extras during the conversion, for example:

```
md2pdf README.md README.pdf --new-extras=fenced-code-blocks

md2pdf README.md README.pdf --new-extras=fenced-code-blocks,mermaid
```

I'm not sure my approach to solving the problem is the better option, so I'm looking forward to your feedback. 

I made some manual tests locally and everything went well, but when I tried to run `pytest` it run an error that I couldn't understand:

```
(venv) ➜  md2pdf git:(include-custom-extras) pytest                        
ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
pytest: error: unrecognized arguments: --cov=md2pdf --cov-report
  inifile: /home/gabrielbdornas/code/gabrielbdornas/md2pdf/setup.cfg
  rootdir: /home/gabrielbdornas/code/gabrielbdornas/md2pdf
```

I hope you guys found it useful as well.

Obs.: I didn't update the package version because I didn't how it is managed by you.

Thanks in advance for the opportunity to help!