### PR TITLE
Use docopt-ng for Py 3.12 compat

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 WeasyPrint
-docopt
+docopt-ng
 markdown2


### PR DESCRIPTION
https://github.com/jmaupetit/md2pdf/issues/56

> https://github.com/docopt/docopt is unmaintained and is not fully compatible with Python 3.12 due to its use of [invalid escape sequences](https://github.com/docopt/docopt/pull/507).
> 
> There is a maintained fork of docopt called [docopt-ng](https://github.com/jazzband/docopt-ng) that is a drop in replacement. By migrating to docopt-ng this project is more likely to be compatible with Python 3.12.

