### PR TITLE
added font config support (this allows custom fonts such as google fonts)

### DIFF
--- a/md2pdf/core.py
+++ b/md2pdf/core.py
@@ -7,6 +7,7 @@ import frontmatter
 from jinja2 import Template
 from markdown import markdown
 from weasyprint import CSS, HTML
+from weasyprint.text.fonts import FontConfiguration
 
 from .conf import MARKDOWN_EXTRAS
 from .exceptions import ValidationError
@@ -66,8 +67,9 @@ def md2pdf(
 
     # Get styles
     styles: list = []
+    font_config = FontConfiguration()
     if css:
-        styles.append(CSS(filename=css))
+        styles.append(CSS(filename=css), font_config=font_config)
 
     # Generate PDF
-    html.write_pdf(pdf, stylesheets=styles)
+    html.write_pdf(pdf, stylesheets=styles, font_config=font_config)


### PR DESCRIPTION
Added FontConfiguration object from weasyprint

 - Allows for custom font-faces for example: 

`@font-face {
  font-family: "Figtree";
  font-style: normal;
  font-weight: 600;
  font-display: swap;
  src: url(https://fonts.gstatic.com/s/figtree/v6/_Xms-HUzqDCFdgfMm4S9DQ.woff2)
    format("woff2");
  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
    U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193,
    U+2212, U+2215, U+FEFF, U+FFFD;
}`

This will now download and embed the above google font into the resulting pdf