### PR TITLE
🔖(major) bump release to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-01-09
+
 ### Added
 
 - Add an Alpine Linux lightweight Docker image
@@ -65,7 +67,8 @@ and this project adheres to
 
 - Add current directory as `base_url` to md2pdf script (Fix #6)
 
-[unreleased]: https://github.com/jmaupetit/md2pdf/compare/1.0.1...main
+[unreleased]: https://github.com/jmaupetit/md2pdf/compare/2.0.0...main
+[2.0.0]: https://github.com/jmaupetit/md2pdf/compare/1.0.1...2.0.0
 [1.0.1]: https://github.com/jmaupetit/md2pdf/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/jmaupetit/md2pdf/compare/0.6...1.0.0
 [0.6]: https://github.com/jmaupetit/md2pdf/compare/0.5...0.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "md2pdf"
-version = "2.0.0b0"
+version = "2.0.0"
 description = "The Markdown to PDF conversion tool with styles"
 authors = [
   {name="Julien Maupetit", email="julien@maupetit.net"},

--- a/uv.lock
+++ b/uv.lock
@@ -541,7 +541,7 @@ wheels = [
 
 [[package]]
 name = "md2pdf"
-version = "2.0.0b0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
### Added

- Add an Alpine Linux lightweight Docker image
- Consider every input markdown source as a Jinja template

### Changed

- Switch to `uv` for packaging and dependency management
- Add extra extensions to the default extensions list

### Removed

- Drop support for python < 3.10
