### PR TITLE
🐛(docker) fix missing extra dependencies

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -16,5 +16,21 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - name: Build Docker (debian) image
         run: make build-docker-debian
+      - name: Test (debian) image 
+        run: |
+          docker run --rm \
+            -u "$(id -u):$(id -g)" \
+            -v $PWD:/wrk \
+            -w /wrk \
+            jmaupetit/md2pdf:latest -i README.md && \
+          ls README.pdf
       - name: Build Docker (alpine) image
         run: make build-docker-alpine
+      - name: Test (alpine) image 
+        run: |
+          docker run --rm \
+            -u "$(id -u):$(id -g)" \
+            -v $PWD:/wrk \
+            -w /wrk \
+            jmaupetit/md2pdf:alpine -i README.md && \
+          ls README.pdf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed 
+
+- Docker: add missing extra dependencies
+
 ## [3.0.0] - 2026-01-22
 
 ### Added 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ COPY . /app
 
 # Sync the project
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-editable
+    uv sync --extra cli --extra latex --locked --no-editable
 
 #
 # -- PRODUCTION --

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -36,7 +36,7 @@ COPY . /app
 
 # Sync the project
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-editable
+    uv sync --extra cli --extra latex --locked --no-editable
 
 #
 # -- PRODUCTION --

--- a/README.md
+++ b/README.md
@@ -103,22 +103,26 @@ Function arguments:
 
 ### With Docker
 
-Install [Docker](https://www.docker.com/)
-
-Pull the image:
+Considering [docker](https://www.docker.com/) is installed, pull the latest
+Debian-based image:
 
 ```bash
-$ docker pull jmaupetit/md2pdf
+$ docker pull jmaupetit/md2pdf:latest
 ```
 
-Now run your image:
+And try to run a smoke test with this image:
 
 ```bash
-$ docker run --rm \
-    -v $PWD:/app \
+$ docker run --rm -t \
+    -v $PWD:/wrk \
     -u "$(id -u):$(id -g)" \
-    jmaupetit/md2pdf --css styles.css -i INPUT.MD -o OUTPUT.PDF
+    -w /wrk \
+    jmaupetit/md2pdf:latest -i README.md
 ```
+
+> There is also a smaller Alpine-based image tagged `alpine`. For a full list
+> of available tags, check the project's [DockerHub
+> repository](https://hub.docker.com/r/jmaupetit/md2pdf/tags).
 
 ### Use Jinja templates as input
 


### PR DESCRIPTION
## Purpose

All extra dependencies are not installed during the Docker build.

## Proposal

- [x] sync extra dependencies in both Debian- and Alpine-based images
- [x] add Docker images smoke test in the CI
- [x] update the documentation
