### PR TITLE
🔇(docker) remove fontconfig warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Docker: fix fontconfig warning message by settings `/tmp` as home directory
+
 ## [3.0.1] - 2026-01-27
 
 ### Fixed 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 #
 FROM base AS production
 
+# Use a temporary home directory (with write permissions)
+ENV HOME=/tmp
+
 # Copy the environment, but not the source code
 COPY --from=builder --chown=app:app /app/.venv /app/.venv
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -43,6 +43,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 #
 FROM base AS production
 
+# Use a temporary home directory (with write permissions)
+ENV HOME=/tmp
+
 # Copy the environment, but not the source code
 COPY --from=builder --chown=app:app /app/.venv /app/.venv
 


### PR DESCRIPTION
## Purpose

If fontconfig has no writable cache directory, it raises the following warning message:

    Fontconfig error: No writable cache directories

## Proposal

By setting `/tmp` as the user home directory, it now has a writable cache directory.
